### PR TITLE
5 update manifest generation

### DIFF
--- a/ez_utils.py
+++ b/ez_utils.py
@@ -530,10 +530,10 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
-def create_platform_metadata(oht_type):
+def create_platform_metadata(oht_type, main_uuid):
     return {
         "iuclidVersion": "7.0.7",
-        "documentKey": f"{generate_uuid()}/{generate_uuid()}",
+        "documentKey": f"{generate_uuid()}/{main_uuid}",
         "parentDocumentKey": "",
         "name": "",
         "documentType": oht_type,
@@ -619,7 +619,8 @@ def create_instance_from_csv_row(oht_class, nested_classes, row_data):
     return oht_instance
 
 
-def map_csv_to_oht_instances(data, test_material_uuid_map, test_material_columns, substance_uuid_map, substance_columns):
+def map_csv_to_oht_instances(data, test_material_uuid_map, test_material_columns, substance_uuid_map, substance_columns,
+                             main_uuid):
     oht_instances = []
     #st.write(data)
     for index, row in data.iterrows():
@@ -660,7 +661,7 @@ def map_csv_to_oht_instances(data, test_material_uuid_map, test_material_columns
                 substance_uuid = substance_uuid_map[substance_values]
 
         if not hasattr(oht_instance, 'uuid'):
-            oht_instance.uuid = f"{generate_uuid()}/{generate_uuid()}"
+            oht_instance.uuid = f"{generate_uuid()}/{main_uuid}"
 
         oht_instances.append((oht_instance, substance_uuid))
     #st.write('done')
@@ -694,7 +695,7 @@ def create_xml_serializer(oht_type):
     return serializer, ns_map  # Return the serializer and namespace mapping
 
 
-def instance_to_i6d(instance, output_dir, oht_type, parent_key=None, is_attachment=False):
+def instance_to_i6d(instance, output_dir, oht_type, main_uuid, parent_key=None, is_attachment=False):
     """Convert an instance to an i6d XML file."""
     # Create an XML serializer and namespace mapping for the given OHT type
     serializer, ns_map = create_xml_serializer(oht_type)
@@ -706,7 +707,7 @@ def instance_to_i6d(instance, output_dir, oht_type, parent_key=None, is_attachme
     xml_content = xml_content.split("?>", 1)[1].strip()
     document_type = to_document_type_format(oht_type)
     # Create platform metadata for the i6d file
-    platform_metadata = create_platform_metadata(document_type)
+    platform_metadata = create_platform_metadata(document_type, main_uuid)
     if parent_key:
         platform_metadata['parentDocumentKey'] = parent_key
     platform_metadata['documentKey'] = instance.uuid
@@ -769,20 +770,76 @@ def instance_to_i6d(instance, output_dir, oht_type, parent_key=None, is_attachme
     return document_key
 
 
-def create_manifest(i6d_files, file_path):
-    """Create a manifest XML file that lists all i6d files."""
-    # Create the root element for the manifest
-    root = etree.Element("Manifest")
+def create_manifest(i6d_files, file_path, main_uuid):
+    """
+    Create a manifest XML file that lists all i6d files, with general-information and contained-documents sections.
+    Args:
+        i6d_files (list): List of i6d file paths (full or relative).
+        file_path (str): Path to write the manifest.xml.
+        main_uuid (str): The main UUID to use for base-document-uuid.
+    """
+    NS = "http://iuclid6.echa.europa.eu/namespaces/manifest/v1"
+    XLINK = "http://www.w3.org/1999/xlink"
+    NSMAP = {None: NS, "xlink": XLINK}
 
-    # Add an entry for each i6d file to the manifest
+    # Root <manifest>
+    root = etree.Element("{%s}manifest" % NS, nsmap=NSMAP)
+
+    # <general-information>
+    general_info = etree.SubElement(root, "{%s}general-information" % NS)
+    etree.SubElement(general_info, "{%s}title" % NS).text = "IUCLID 6 container manifest file"
+    etree.SubElement(general_info, "{%s}created" % NS).text = datetime.datetime.utcnow().isoformat() + "Z"
+    etree.SubElement(general_info, "{%s}author" % NS).text = "EZ Mapper"
+    etree.SubElement(general_info, "{%s}application" % NS).text = "IUCLID6 (EZ Mapper Export)"
+    etree.SubElement(general_info, "{%s}submission-type" % NS).text = "EXPERIMENTAL_DATA"
+    etree.SubElement(general_info, "{%s}archive-type" % NS).text = "DOSSIER_DATA"
+    etree.SubElement(general_info, "{%s}partial" % NS).text = "false"
+
+    # <base-document-uuid>
+    base_uuid = f"{main_uuid}/{main_uuid}"
+    etree.SubElement(root, "{%s}base-document-uuid" % NS).text = base_uuid
+
+    # <contained-documents>
+    contained_docs = etree.SubElement(root, "{%s}contained-documents" % NS)
+
     for i6d_file in i6d_files:
-        entry = etree.SubElement(root, "Entry")  # Create an Entry element
-        entry.text = i6d_file  # Set the text of the Entry element to the i6d file name
+        uuid_underscore = os.path.splitext(os.path.basename(i6d_file))[0]
+        uuid_slash = uuid_underscore.replace("_", "/")
+        file_name = os.path.basename(i6d_file)
+        file_path_full = os.path.join(os.path.dirname(file_path), i6d_file)
+        if os.path.exists(file_path_full):
+            mod_time = datetime.datetime.utcfromtimestamp(os.path.getmtime(file_path_full)).isoformat() + "Z"
+        else:
+            mod_time = datetime.datetime.utcnow().isoformat() + "Z"
 
-    # Create an XML tree from the root element
+        # --- Extract documentType and documentSubType from the i6d file ---
+        try:
+            tree = etree.parse(file_path_full)
+            nsmap = {
+                "i6c": "http://iuclid6.echa.europa.eu/namespaces/platform-container/v2",
+                "i6m": "http://iuclid6.echa.europa.eu/namespaces/platform-metadata/v1"
+            }
+            doc_type = tree.findtext(".//i6m:documentType", namespaces=nsmap)
+            doc_subtype = tree.findtext(".//i6m:documentSubType", namespaces=nsmap)
+        except Exception as e:
+            doc_type = None
+            doc_subtype = None
+
+        doc_elem = etree.SubElement(contained_docs, "{%s}document" % NS, id=uuid_slash)
+        # Use extracted type/subtype, fallback to "DOSSIER"/"EXPERIMENTAL_DATA"
+        etree.SubElement(doc_elem, "{%s}type" % NS).text = doc_type if doc_type else "DOSSIER"
+        if doc_subtype and doc_subtype.strip():
+            etree.SubElement(doc_elem, "{%s}subtype" % NS).text = doc_subtype
+        name_elem = etree.SubElement(doc_elem, "{%s}name" % NS)
+        name_elem.text = file_name
+        name_elem.attrib["{%s}type" % XLINK] = "simple"
+        name_elem.attrib["{%s}href" % XLINK] = f"{uuid_underscore}.i6d"
+        etree.SubElement(doc_elem, "{%s}first-modification-date" % NS).text = mod_time
+        etree.SubElement(doc_elem, "{%s}last-modification-date" % NS).text = mod_time
+        etree.SubElement(doc_elem, "{%s}uuid" % NS).text = uuid_slash
+
+    # Write the XML tree to file
     tree = etree.ElementTree(root)
-
-    # Write the XML tree to a file
     tree.write(file_path, pretty_print=True, xml_declaration=True, encoding="UTF-8")
 
 
@@ -791,7 +848,7 @@ def save_dataframe_as_excel(data, file_path):
 
 
 def generate_i6z(endpoint_instances, test_material_instances, legal_entity_instances, ref_sub_instances,
-                 substance_instances, output_dir, i6z_file_path, data, other_files):
+                 substance_instances, output_dir, i6z_file_path, data, other_files, main_uuid):
     """Generate an i6z file containing multiple instances."""
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)
@@ -801,25 +858,25 @@ def generate_i6z(endpoint_instances, test_material_instances, legal_entity_insta
         for i, instance in enumerate(test_material_instances):
             # Determine the OHT type from the instance class name
             oht_type = type(instance).__name__.replace("TestMaterialInformation", "")
-            document_key = instance_to_i6d(instance, output_dir, "TestMaterialInformation")
+            document_key = instance_to_i6d(instance, output_dir, "TestMaterialInformation", main_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
     if legal_entity_instances is not None:
         for i, instance in enumerate(legal_entity_instances):
-            document_key = instance_to_i6d(instance, output_dir, "LegalEntity")
+            document_key = instance_to_i6d(instance, output_dir, "LegalEntity", main_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
     if ref_sub_instances is not None:
         for i, instance in enumerate(ref_sub_instances):
-            document_key = instance_to_i6d(instance, output_dir, "ReferenceSubstance")
+            document_key = instance_to_i6d(instance, output_dir, "ReferenceSubstance", main_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
     if substance_instances is not None:
         for i, instance in enumerate(substance_instances):
-            document_key = instance_to_i6d(instance, output_dir, "Substance")
+            document_key = instance_to_i6d(instance, output_dir, "Substance", main_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
@@ -842,14 +899,14 @@ def generate_i6z(endpoint_instances, test_material_instances, legal_entity_insta
     if other_files is not None:
         attach_keys = []
         for attachment in other_files:
-            document_key = create_i6d_for_attachment(attachment, output_dir)
+            document_key = create_i6d_for_attachment(attachment, output_dir, main_uuid)
             attach_keys.append(f"{document_key}.i6d")
 
     # Define the file path for the manifest
     manifest_file_path = os.path.join(output_dir, "manifest.xml")
 
     # Create the manifest file
-    create_manifest(i6d_files, manifest_file_path)
+    create_manifest(i6d_files, manifest_file_path, main_uuid)
     main_data = os.path.join(output_dir, "data.xlsx")
     save_dataframe_as_excel(data, main_data)
     other_file_paths = save_uploaded_files(other_files, output_dir)
@@ -950,7 +1007,7 @@ def save_uploaded_files(uploaded_files, output_dir):
     return file_paths
 
 
-def create_test_material_instances(data, test_material_columns):
+def create_test_material_instances(data, test_material_columns, main_uuid):
     test_material_instances = []
     test_material_uuid_map = {}
 
@@ -963,7 +1020,7 @@ def create_test_material_instances(data, test_material_columns):
             {},
             filtered_row
         )
-        uuid_str = f"{generate_uuid()}/{generate_uuid()}"
+        uuid_str = f"{generate_uuid()}/{main_uuid}"
         test_material_instance.uuid = uuid_str
         test_material_instances.append(test_material_instance)
         test_material_values = tuple(row[col] for col in test_material_columns)
@@ -972,7 +1029,7 @@ def create_test_material_instances(data, test_material_columns):
     return test_material_instances, test_material_uuid_map
 
 
-def create_substance_instances(data, substance_columns, ref_sub_uuid_map, ref_sub_columns):
+def create_substance_instances(data, substance_columns, ref_sub_uuid_map, ref_sub_columns, main_uuid):
     substance_instances = []
     substances_uuid_map = {}
 
@@ -985,7 +1042,7 @@ def create_substance_instances(data, substance_columns, ref_sub_uuid_map, ref_su
             {},
             filtered_row
         )
-        uuid_str = f"{generate_uuid()}/{generate_uuid()}"
+        uuid_str = f"{generate_uuid()}/{main_uuid}"
         substance_instance.uuid = uuid_str
         if ref_sub_columns:
             ref_sub_values = tuple(row[col] for col in ref_sub_columns if col in row)
@@ -1000,7 +1057,7 @@ def create_substance_instances(data, substance_columns, ref_sub_uuid_map, ref_su
     return substance_instances, substances_uuid_map
 
 
-def create_legal_entity_instances(data, legal_entity_columns):
+def create_legal_entity_instances(data, legal_entity_columns, main_uuid):
     legal_entity_instances = []
     legal_entity_uuid_map = {}
 
@@ -1013,7 +1070,7 @@ def create_legal_entity_instances(data, legal_entity_columns):
             {},
             filtered_row
         )
-        uuid_str = f"{generate_uuid()}/{generate_uuid()}"
+        uuid_str = f"{generate_uuid()}/{main_uuid}"
         legal_entity_instance.uuid = uuid_str
         legal_entity_instances.append(legal_entity_instance)
         legal_entity_values = tuple(row[col] for col in legal_entity_columns)
@@ -1022,7 +1079,7 @@ def create_legal_entity_instances(data, legal_entity_columns):
     return legal_entity_instances, legal_entity_uuid_map
 
 
-def create_ref_sub_instances(data, ref_sub_columns):
+def create_ref_sub_instances(data, ref_sub_columns, main_uuid):
     ref_sub_instances = []
     ref_sub_uuid_map = {}
 
@@ -1035,7 +1092,7 @@ def create_ref_sub_instances(data, ref_sub_columns):
             {},
             filtered_row
         )
-        uuid_str = f"{generate_uuid()}/{generate_uuid()}"
+        uuid_str = f"{generate_uuid()}/{main_uuid}"
         ref_sub_instance.uuid = uuid_str
         ref_sub_instances.append(ref_sub_instance)
         ref_sub_values = tuple(row[col] for col in ref_sub_columns)
@@ -1134,12 +1191,12 @@ def determine_mime_type(file_name):
         raise ValueError(f"Unsupported file type: {file_extension}")
 
 
-def create_i6d_for_attachment(attachment_file, output_dir):
+def create_i6d_for_attachment(attachment_file, output_dir, main_uuid):
     file_name = attachment_file.name
     file_content = attachment_file.getvalue()
     md5_hash = compute_mp5(file_content)
     mime_type = determine_mime_type(file_name)
-    document_key = f"{generate_uuid()}/{generate_uuid()}"
+    document_key = f"{generate_uuid()}/{main_uuid}"
     creation_date = datetime.datetime.utcnow().isoformat() + "Z"
     root = etree.Element("Attachment",
                          nsmap={

--- a/ez_utils.py
+++ b/ez_utils.py
@@ -532,14 +532,24 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
-def create_platform_metadata(oht_type, main_uuid):
+def create_platform_metadata(instance, oht_type, main_uuid):
+    docType = oht_type
+    docSubType = ""
+    # TODO create list of document types to exclude - add document_type param based on earlier ifelse
+    if 'EndpointStudyRecord' in type(instance).__name__:
+       print("Setting documentType to ENDPOINT_STUDY_RECORD: 1")
+       docType = "ENDPOINT_STUDY_RECORD"
+       docSubType = snake_to_camel(oht_type)
+    else:
+        print("Setting documentType to ENDPOINT_STUDY_RECORD: 0")
+       
     return {
         "iuclidVersion": "7.0.7",
         "documentKey": f"{generate_uuid()}/{main_uuid}",
         "parentDocumentKey": "",
         "name": "",
-        "documentType": "ENDPOINT_STUDY_RECORD",
-        "documentSubType": snake_to_camel(oht_type),
+        "documentType": docType,
+        "documentSubType": docSubType,
         "orderInSectionNo": "1",
         "definitionVersion": "8.0",
         "creationDate": datetime.datetime.utcnow().isoformat() + "Z",
@@ -716,7 +726,9 @@ def instance_to_i6d(instance, output_dir, oht_type, main_uuid, parent_key=None, 
     xml_content = xml_content.split("?>", 1)[1].strip()
     document_type = to_document_type_format(oht_type)
     # Create platform metadata for the i6d file
-    platform_metadata = create_platform_metadata(document_type, main_uuid)
+    platform_metadata = create_platform_metadata(instance=instance, 
+                                                 oht_type = document_type, 
+                                                 main_uuid = main_uuid)
     if parent_key:
         platform_metadata['parentDocumentKey'] = f'{parent_key}/{main_uuid}'
     platform_metadata['documentKey'] = instance.uuid

--- a/ez_utils.py
+++ b/ez_utils.py
@@ -507,6 +507,8 @@ def parse_column_name(column_name: str):
 def camel_to_snake(name):
     return re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
 
+def snake_to_camel(name):
+    return "".join([t.capitalize() for t in name.split('_')])
 
 def to_document_type_format(oht_type):
     return "_".join(re.findall(r'[A-Z][^A-Z]*', oht_type)).upper()
@@ -536,8 +538,8 @@ def create_platform_metadata(oht_type, main_uuid):
         "documentKey": f"{generate_uuid()}/{main_uuid}",
         "parentDocumentKey": "",
         "name": "",
-        "documentType": oht_type,
-        "documentSubType": "",
+        "documentType": "ENDPOINT_STUDY_RECORD",
+        "documentSubType": snake_to_camel(oht_type),
         "orderInSectionNo": "1",
         "definitionVersion": "8.0",
         "creationDate": datetime.datetime.utcnow().isoformat() + "Z",
@@ -675,8 +677,11 @@ def create_xml_serializer(oht_type):
     except Exception as e:
         print("Error in create_xml_serializer:", e)
     # Build the context recursively to include all related classes
-    context.build_recursive(get_oht_classes(oht_type)[0])
-
+    try:
+        context.build_recursive(get_oht_classes(oht_type)[0])
+    except Exception as e:
+        print(f"Context build_recursive error: {e}")
+    
     # Define the namespace mapping for the XML document
     ns_map = {
         None: f"http://iuclid6.echa.europa.eu/namespaces/ENDPOINT_STUDY_RECORD-{oht_type}/9.0",  # Default namespace
@@ -697,49 +702,56 @@ def create_xml_serializer(oht_type):
 
 def instance_to_i6d(instance, output_dir, oht_type, main_uuid, parent_key=None, is_attachment=False):
     """Convert an instance to an i6d XML file."""
+    if main_uuid is None:
+        return
     # Create an XML serializer and namespace mapping for the given OHT type
     serializer, ns_map = create_xml_serializer(oht_type)
-
     # Serialize the instance to XML
-    xml_content = serializer.render(instance, ns_map)
-
+    try:
+        xml_content = serializer.render(instance, ns_map)
+    except Exception as e:
+        print(f"xml_content error: {e}")
+   
     # Remove the XML declaration from the serialized content
     xml_content = xml_content.split("?>", 1)[1].strip()
     document_type = to_document_type_format(oht_type)
     # Create platform metadata for the i6d file
     platform_metadata = create_platform_metadata(document_type, main_uuid)
     if parent_key:
-        platform_metadata['parentDocumentKey'] = parent_key
+        platform_metadata['parentDocumentKey'] = f'{parent_key}/{main_uuid}'
     platform_metadata['documentKey'] = instance.uuid
 
     # Format the platform metadata as an XML string
     platform_metadata_xml = f"""
-    <PlatformMetadata xmlns="http://iuclid6.echa.europa.eu/namespaces/platform-metadata/v1">
-        <iuclidVersion>{platform_metadata['iuclidVersion']}</iuclidVersion>
-        <documentKey>{platform_metadata['documentKey']}</documentKey>
-        <parentDocumentKey>{platform_metadata['parentDocumentKey']}</parentDocumentKey>
-        <name>{platform_metadata['name']}</name>
-        <documentType>{platform_metadata['documentType']}</documentType>
-        <documentSubType>{platform_metadata['documentSubType']}</documentSubType>
-        <orderInSectionNo>{platform_metadata['orderInSectionNo']}</orderInSectionNo>
-        <definitionVersion>{platform_metadata['definitionVersion']}</definitionVersion>
-        <creationDate>{platform_metadata['creationDate']}</creationDate>
-        <lastModificationDate>{platform_metadata['lastModificationDate']}</lastModificationDate>
-        <submissionType>{platform_metadata['submissionType']}</submissionType>
-        <submissionTypeVersion>{platform_metadata['submissionTypeVersion']}</submissionTypeVersion>
-        <submittingLegalEntity>{platform_metadata['submittingLegalEntity']}</submittingLegalEntity>
-        <dossierSubject>{platform_metadata['dossierSubject']}</dossierSubject>
-        <i5Origin>{platform_metadata['i5Origin']}</i5Origin>
-        <creationTool>{platform_metadata['creationTool']}</creationTool>
-        <snapshotCreationTool>{platform_metadata['snapshotCreationTool']}</snapshotCreationTool>
-    </PlatformMetadata>
+    <i6c:PlatformMetadata 
+        xmlns:i6c="http://iuclid6.echa.europa.eu/namespaces/platform-container/v2"
+        xmlns:i6m="http://iuclid6.echa.europa.eu/namespaces/platform-metadata/v1">
+        <i6m:iuclidVersion>{platform_metadata['iuclidVersion']}</i6m:iuclidVersion>
+        <i6m:documentKey>{platform_metadata['documentKey']}</i6m:documentKey>
+        <i6m:parentDocumentKey>{platform_metadata['parentDocumentKey']}</i6m:parentDocumentKey>
+        <i6m:name>{platform_metadata['name']}</i6m:name>
+        <i6m:documentType>{platform_metadata['documentType']}</i6m:documentType>
+        <i6m:documentSubType>{platform_metadata['documentSubType']}</i6m:documentSubType>
+        <i6m:orderInSectionNo>{platform_metadata['orderInSectionNo']}</i6m:orderInSectionNo>
+        <i6m:definitionVersion>{platform_metadata['definitionVersion']}</i6m:definitionVersion>
+        <i6m:creationDate>{platform_metadata['creationDate']}</i6m:creationDate>
+        <i6m:lastModificationDate>{platform_metadata['lastModificationDate']}</i6m:lastModificationDate>
+        <i6m:submissionType>{platform_metadata['submissionType']}</i6m:submissionType>
+        <i6m:submissionTypeVersion>{platform_metadata['submissionTypeVersion']}</i6m:submissionTypeVersion>
+        <i6m:submittingLegalEntity>{platform_metadata['submittingLegalEntity']}</i6m:submittingLegalEntity>
+        <i6m:dossierSubject>{platform_metadata['dossierSubject']}</i6m:dossierSubject>
+        <i6m:i5Origin>{platform_metadata['i5Origin']}</i6m:i5Origin>
+        <i6m:creationTool>{platform_metadata['creationTool']}</i6m:creationTool>
+        <i6m:snapshotCreationTool>{platform_metadata['snapshotCreationTool']}</i6m:snapshotCreationTool>
+    </i6c:PlatformMetadata>
     """
 
     # Define the namespace mapping for the entire i6d document
     ns_map = {
         None: f"http://iuclid6.echa.europa.eu/namespaces/ENDPOINT_STUDY_RECORD-{oht_type}/9.0",  # Default namespace
         "i6c": "http://iuclid6.echa.europa.eu/namespaces/platform-container/v2",  # Namespace for platform container
-        "xsi": "http://www.w3.org/2001/XMLSchema-instance",  # XML Schema instance namespace
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",  # XML Schema instance namespace,
+        "xml": "http://www.w3.org/XML/1998/namespace"
     }
 
     # Create the root element for the i6d document with the specified namespaces
@@ -783,24 +795,39 @@ def create_manifest(i6d_files, file_path, main_uuid):
     NSMAP = {None: NS, "xlink": XLINK}
 
     # Root <manifest>
-    root = etree.Element("{%s}manifest" % NS, nsmap=NSMAP)
+    root = etree.Element(f"{{{NS}}}manifest", nsmap=NSMAP)
 
     # <general-information>
-    general_info = etree.SubElement(root, "{%s}general-information" % NS)
-    etree.SubElement(general_info, "{%s}title" % NS).text = "IUCLID 6 container manifest file"
-    etree.SubElement(general_info, "{%s}created" % NS).text = datetime.datetime.utcnow().isoformat() + "Z"
-    etree.SubElement(general_info, "{%s}author" % NS).text = "EZ Mapper"
-    etree.SubElement(general_info, "{%s}application" % NS).text = "IUCLID6 (EZ Mapper Export)"
-    etree.SubElement(general_info, "{%s}submission-type" % NS).text = "EXPERIMENTAL_DATA"
-    etree.SubElement(general_info, "{%s}archive-type" % NS).text = "DOSSIER_DATA"
-    etree.SubElement(general_info, "{%s}partial" % NS).text = "false"
+    general_info = etree.SubElement(root, f"{{{NS}}}general-information")
+    etree.SubElement(general_info, f"{{{NS}}}title").text = "IUCLID 6 container manifest file"
+    etree.SubElement(general_info, f"{{{NS}}}created").text = datetime.datetime.utcnow().isoformat() + "Z"
+    etree.SubElement(general_info, f"{{{NS}}}author").text = "EZ Mapper"
+    etree.SubElement(general_info, f"{{{NS}}}application").text = "IUCLID6 (EZ Mapper Export)"
+    etree.SubElement(general_info, f"{{{NS}}}submission-type").text = "EXPERIMENTAL_DATA"
+    etree.SubElement(general_info, f"{{{NS}}}archive-type").text = "DOSSIER_DATA"
+    # TODO Add legistlations-info tags?
+    legislation_list = etree.SubElement(general_info, f"{{{NS}}}legislations-info")
+    legislation = etree.SubElement(legislation_list, f"{{{NS}}}legislation")
+    # domain legislation
+    etree.SubElement(legislation, f"{{{NS}}}id").text = "domain"
+    etree.SubElement(legislation, f"{{{NS}}}version").text = "8.0"
+    # core legislation
+    legislation = etree.SubElement(legislation_list, f"{{{NS}}}legislation")
+    etree.SubElement(legislation, f"{{{NS}}}id").text = "core"
+    etree.SubElement(legislation, f"{{{NS}}}version").text = "8.0"
+    # oecd legislation
+    legislation = etree.SubElement(legislation_list, f"{{{NS}}}legislation")
+    etree.SubElement(legislation, f"{{{NS}}}id").text = "oecd"
+    etree.SubElement(legislation, f"{{{NS}}}version").text = "8.0"
+    # TODO Is "partial" tag needed?
+    # etree.SubElement(general_info, f"{{{NS}}}partial").text = "false"
 
     # <base-document-uuid>
     base_uuid = f"{main_uuid}/{main_uuid}"
-    etree.SubElement(root, "{%s}base-document-uuid" % NS).text = base_uuid
+    etree.SubElement(root, f"{{{NS}}}base-document-uuid").text = base_uuid
 
     # <contained-documents>
-    contained_docs = etree.SubElement(root, "{%s}contained-documents" % NS)
+    contained_docs = etree.SubElement(root, f"{{{NS}}}contained-documents")
 
     for i6d_file in i6d_files:
         uuid_underscore = os.path.splitext(os.path.basename(i6d_file))[0]
@@ -825,22 +852,32 @@ def create_manifest(i6d_files, file_path, main_uuid):
             doc_type = None
             doc_subtype = None
 
-        doc_elem = etree.SubElement(contained_docs, "{%s}document" % NS, id=uuid_slash)
+        doc_elem = etree.SubElement(contained_docs, f"{{{NS}}}document", id=uuid_slash)
         # Use extracted type/subtype, fallback to "DOSSIER"/"EXPERIMENTAL_DATA"
-        etree.SubElement(doc_elem, "{%s}type" % NS).text = doc_type if doc_type else "DOSSIER"
+        etree.SubElement(doc_elem, f"{{{NS}}}type").text = doc_type if doc_type else "DOSSIER"
         if doc_subtype and doc_subtype.strip():
-            etree.SubElement(doc_elem, "{%s}subtype" % NS).text = doc_subtype
-        name_elem = etree.SubElement(doc_elem, "{%s}name" % NS)
+            etree.SubElement(doc_elem, f"{{{NS}}}subtype").text = doc_subtype
+        name_elem = etree.SubElement(doc_elem, f"{{{NS}}}name")
         name_elem.text = file_name
-        name_elem.attrib["{%s}type" % XLINK] = "simple"
-        name_elem.attrib["{%s}href" % XLINK] = f"{uuid_underscore}.i6d"
-        etree.SubElement(doc_elem, "{%s}first-modification-date" % NS).text = mod_time
-        etree.SubElement(doc_elem, "{%s}last-modification-date" % NS).text = mod_time
-        etree.SubElement(doc_elem, "{%s}uuid" % NS).text = uuid_slash
+        name_elem.attrib[f"{{{XLINK}}}type"] = "simple"
+        name_elem.attrib[f"{{{XLINK}}}href"] = f"{uuid_underscore}.i6d"
+        etree.SubElement(doc_elem, f"{{{NS}}}first-modification-date").text = mod_time
+        etree.SubElement(doc_elem, f"{{{NS}}}last-modification-date").text = mod_time
+        etree.SubElement(doc_elem, f"{{{NS}}}uuid").text = uuid_slash
 
+    # # Prepare XSL stylesheet tag
+    # stylesheet_pi = etree.ProcessingInstruction(
+    #     "xml-stylesheet", 'type="text/xsl" href="manifest.xsl"'
+    # )
+    # # Insert the processing instruction at the beginning of the tree
+    # root.addprevious(stylesheet_pi)
+    
     # Write the XML tree to file
     tree = etree.ElementTree(root)
+    
     tree.write(file_path, pretty_print=True, xml_declaration=True, encoding="UTF-8")
+    # Print the XML with the added stylesheet instruction
+    # print(etree.tostring(tree, pretty_print=True, xml_declaration=True, encoding='UTF-8').decode())
 
 
 def save_dataframe_as_excel(data, file_path):
@@ -848,7 +885,7 @@ def save_dataframe_as_excel(data, file_path):
 
 
 def generate_i6z(endpoint_instances, test_material_instances, legal_entity_instances, ref_sub_instances,
-                 substance_instances, output_dir, i6z_file_path, data, other_files, main_uuid):
+                 substance_instances, output_dir, i6z_file_path, data, other_files, main_uuid, parent_uuid):
     """Generate an i6z file containing multiple instances."""
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)
@@ -858,25 +895,25 @@ def generate_i6z(endpoint_instances, test_material_instances, legal_entity_insta
         for i, instance in enumerate(test_material_instances):
             # Determine the OHT type from the instance class name
             oht_type = type(instance).__name__.replace("TestMaterialInformation", "")
-            document_key = instance_to_i6d(instance, output_dir, "TestMaterialInformation", main_uuid)
+            document_key = instance_to_i6d(instance, output_dir, "TestMaterialInformation", main_uuid=main_uuid, parent_key=parent_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
     if legal_entity_instances is not None:
         for i, instance in enumerate(legal_entity_instances):
-            document_key = instance_to_i6d(instance, output_dir, "LegalEntity", main_uuid)
+            document_key = instance_to_i6d(instance, output_dir, "LegalEntity", main_uuid=main_uuid, parent_key=parent_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
     if ref_sub_instances is not None:
         for i, instance in enumerate(ref_sub_instances):
-            document_key = instance_to_i6d(instance, output_dir, "ReferenceSubstance", main_uuid)
+            document_key = instance_to_i6d(instance, output_dir, "ReferenceSubstance", main_uuid=main_uuid, parent_key=parent_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
     if substance_instances is not None:
         for i, instance in enumerate(substance_instances):
-            document_key = instance_to_i6d(instance, output_dir, "Substance", main_uuid)
+            document_key = instance_to_i6d(instance, output_dir, "Substance", main_uuid=main_uuid, parent_key=parent_uuid)
             i6d_file_path = f"{document_key}.i6d"
             i6d_files.append(i6d_file_path)
 
@@ -884,7 +921,7 @@ def generate_i6z(endpoint_instances, test_material_instances, legal_entity_insta
         # Determine the OHT type from the instance class name
         oht_type = type(instance).__name__.replace("EndpointStudyRecord", "")
         #st.write(oht_type)
-        document_key = instance_to_i6d(instance, output_dir, oht_type, parent_key)
+        document_key = instance_to_i6d(instance, output_dir, oht_type, main_uuid=main_uuid, parent_key=parent_uuid)
         #st.write(document_key)
         i6d_file_path = f"{document_key}.i6d"
         # Define the file path for the i6d file
@@ -1115,8 +1152,6 @@ def get_model_fields(model, prefix=""):
     for field_name, field_type in model.__annotations__.items():
         full_path = f"{prefix}.{field_name}" if prefix else field_name
         actual_type = get_actual_type2(field_type)
-        #print('actual_type:')
-        #print(type(actual_type))
         if isinstance(actual_type, typing._GenericAlias):
             continue
         else:

--- a/ezmapper.py
+++ b/ezmapper.py
@@ -255,6 +255,7 @@ if st.session_state.split_done and selected_df_key != "None":
         generate_i6z_button = st.button("Generate i6z File")
         if generate_i6z_button:
             #st.write('generating')
+            main_uuid = str(uuid.uuid4())
             try:
                 column_mapping_dict = column_mapping
                 data = apply_column_mapping(column_mapping, st.session_state.modified_df)
@@ -262,7 +263,8 @@ if st.session_state.split_done and selected_df_key != "None":
                 #tm_data = data[[col for col in data.columns if col in test_material_columns]]
                 if test_material_columns:
                     test_material_instances, test_material_uuid_map = create_test_material_instances(data,
-                                                                                                 test_material_columns)
+                                                                                                 test_material_columns,
+                                                                                                 main_uuid)
                 else:
                     test_material_instances, test_material_uuid_map = None, None
                 #data = data.drop(columns=[col for col in test_material_columns if col in data.columns])
@@ -270,7 +272,8 @@ if st.session_state.split_done and selected_df_key != "None":
                 #le_data = data[[col for col in data.columns if col in legal_entity_columns]]
                 if legal_entity_columns:
                     legal_entity_instances, legal_entity_uuid_map = create_legal_entity_instances(data,
-                                                                                              legal_entity_columns)
+                                                                                              legal_entity_columns,
+                                                                                              main_uuid)
                 else:
                     legal_entity_instances, legal_entity_uuid_map = None, None
                 #data = data.drop(columns=[col for col in legal_entity_columns if col in data.columns])
@@ -279,7 +282,7 @@ if st.session_state.split_done and selected_df_key != "None":
 
                 #ref_data = data[[col for col in data.columns if col in ref_sub_columns]]
                 if ref_sub_columns:
-                    ref_sub_instances, ref_sub_uuid_map = create_ref_sub_instances(data, ref_sub_columns)
+                    ref_sub_instances, ref_sub_uuid_map = create_ref_sub_instances(data, ref_sub_columns, main_uuid)
                 else:
                     ref_sub_instances, ref_sub_uuid_map = None, None
                 #data = data.drop(columns=[col for col in ref_sub_columns if col in data.columns])
@@ -287,18 +290,19 @@ if st.session_state.split_done and selected_df_key != "None":
                 substance_columns = get_substance_columns(column_mapping_dict)
                 #sub_data = data[[col for col in data.columns if col in substance_columns]]
                 if substance_columns:
-                    substance_instances, substance_uuid_map = create_substance_instances(data, substance_columns, ref_sub_uuid_map, ref_sub_columns)
+                    substance_instances, substance_uuid_map = create_substance_instances(data, substance_columns, ref_sub_uuid_map, 
+                                                                                         ref_sub_columns, main_uuid)
                 else:
                     substance_instances, substance_uuid_map = None, None
                 #data = data.drop(columns=[col for col in substance_columns if col in data.columns])
                 #st.write('prestuff')
 
                 oht_instances = map_csv_to_oht_instances(data, test_material_uuid_map, test_material_columns,
-                                                         substance_uuid_map, substance_columns)
+                                                         substance_uuid_map, substance_columns, main_uuid)
                 output_dir = 'output'
                 i6z_file_path = 'output/data.i6z'
                 generate_i6z(oht_instances, test_material_instances, legal_entity_instances, ref_sub_instances,
-                             substance_instances, output_dir, i6z_file_path, data, uploaded_other_files)
+                             substance_instances, output_dir, i6z_file_path, data, uploaded_other_files, main_uuid)
 
                 st.write("Successfully Generated")
                 outfile_name = base_file_name + '.i6z'

--- a/ezmapper.py
+++ b/ezmapper.py
@@ -77,7 +77,7 @@ if uploaded_file is not None:
     user_df = upload_file_to_df(uploaded_file)
     st.session_state.user_df = user_df
 
-    base_file_name = Path(uploaded_file.name).stem
+    # base_file_name = Path(uploaded_file.name).stem
 
     # Display a preview of the data
     display_data_preview(user_df)
@@ -256,6 +256,7 @@ if st.session_state.split_done and selected_df_key != "None":
         if generate_i6z_button:
             #st.write('generating')
             main_uuid = str(uuid.uuid4())
+            parent_uuid = str(uuid.uuid4())
             try:
                 column_mapping_dict = column_mapping
                 data = apply_column_mapping(column_mapping, st.session_state.modified_df)
@@ -302,10 +303,11 @@ if st.session_state.split_done and selected_df_key != "None":
                 output_dir = 'output'
                 i6z_file_path = 'output/data.i6z'
                 generate_i6z(oht_instances, test_material_instances, legal_entity_instances, ref_sub_instances,
-                             substance_instances, output_dir, i6z_file_path, data, uploaded_other_files, main_uuid)
+                             substance_instances, output_dir, i6z_file_path, data, uploaded_other_files, 
+                             main_uuid=main_uuid, parent_uuid=parent_uuid)
 
                 st.write("Successfully Generated")
-                outfile_name = base_file_name + '.i6z'
+                outfile_name = parent_uuid + '.i6z'
                 st.download_button(
                     label='Download i6z File',
                     data=open(i6z_file_path, 'rb').read(),


### PR DESCRIPTION
Updates to address the i6z IUCLID import error messages related to manifest.xml formatting. Some additional fixes to i6d generation as well. Remaining issue with i6d XSD validation during import still present, but will be addressed in a future branch.

To test changes:
1. Review [I6z formatting](https://iuclid6.echa.europa.eu/documents/1387205/1806384/iuclid_i6z_format_developer_guide_en.pdf/b6cb98f2-499a-aabb-5851-d8383a9bf2ea?t=1580993423107) to ensure all required fields and namespacing is present
2. Create an i6z file with EZ Mapper using the `test_files` folder with `oht67test.csv` and `column_mapping.json`
3. Try to upload to internal IUCLID instance
4. Observe that the request is successful (HTTP 202), but the import had errors with i6d XSD validation. There are not any errors reported related to the manifest as before

You can also examine the contents of the i6z and i6d XML files by unzipping them locally with something like:

```
import zipfile
i6z_file = "path/to/i6z/file.i6z"
temp_dir = "path/to/unzipped/i6z/dir"

with zipfile.ZipFile(i6z_file, "r") as zip_ref:
    zip_ref.extractall(temp_dir)
```